### PR TITLE
2 bugfixes, 2 variants

### DIFF
--- a/MonsterVariants/MainPlugin.cs
+++ b/MonsterVariants/MainPlugin.cs
@@ -32,6 +32,7 @@ namespace MonsterVariants
             //Material glandMat = UnityEngine.Object.Instantiate(itemDisplayRuleSet.FindItemDisplayRuleGroup("BeetleGland").rules[0].followerPrefab.GetComponentInChildren<MeshRenderer>().material);
             Material visionsMat = UnityEngine.Object.Instantiate(itemDisplayRuleSet.FindItemDisplayRuleGroup("LunarPrimaryReplacement").rules[0].followerPrefab.GetComponentInChildren<MeshRenderer>().material);
             Material ghostMat = Resources.Load<Material>("Materials/matGhostEffect");
+            Material shatterspleenMat = UnityEngine.Object.Instantiate(itemDisplayRuleSet.FindItemDisplayRuleGroup("BleedOnHitAndExplode").rules[0].followerPrefab.GetComponentInChildren<MeshRenderer>().material);
 
             //Mesh beedlMesh = Modules.Assets.armoredMesh;
             //Mesh beedlSpeedMesh = Modules.Assets.speedyBeetleMesh;
@@ -75,6 +76,14 @@ namespace MonsterVariants
                     itemString = "Behemoth",
                     count = 3
                 }
+            };
+
+            // Clotted Imp inventory
+            ItemInfo[] clottedInventory = new ItemInfo[]
+            {
+                SimpleItem("UtilitySkillMagazine", 2),
+                SimpleItem("CritGlasses", 4),
+                SimpleItem("BleedOnHitAndExplode", 1)
             };
 
             // Speedy Beetle
@@ -190,6 +199,26 @@ namespace MonsterVariants
                 materialReplacement = null,
                 skillReplacement = null
             });
+
+            // Clotted Imp
+            AddVariant(new MonsterVariantInfo
+            {
+                bodyName = "Imp",
+                spawnRate = Modules.Config.clottedImpSpawnRate.Value,
+                variantTier = MonsterVariantTier.Uncommon,
+                sizeMultiplier = 0.8f,
+                healthMultiplier = 1.2f,
+                moveSpeedMultiplier = 1f,
+                attackSpeedMultiplier = 1f,
+                damageMultiplier = 1f,
+                armorMultiplier = 1f,
+                armorBonus = 0f,
+                customInventory = clottedInventory,
+                meshReplacement = null,
+                materialReplacement = SimpleMaterialReplacement(shatterspleenMat),
+                skillReplacement = null
+            });
+
         }
        
         // helper for simplifying mat replacements

--- a/MonsterVariants/MainPlugin.cs
+++ b/MonsterVariants/MainPlugin.cs
@@ -327,7 +327,7 @@ namespace MonsterVariants
                 damageMultiplier = damage,
                 armorMultiplier = armor,
                 armorBonus = armorBonus,
-                customInventory = null,
+                customInventory = SimpleInventory("AlienHead",alienHeads),
                 meshReplacement = null,
                 materialReplacement = replacementMats,
                 skillReplacement = null,

--- a/MonsterVariants/MainPlugin.cs
+++ b/MonsterVariants/MainPlugin.cs
@@ -2,6 +2,7 @@
 using RoR2;
 using RoR2.Skills;
 using UnityEngine;
+using System.Collections.Generic;
 
 namespace MonsterVariants
 {
@@ -92,7 +93,7 @@ namespace MonsterVariants
             {
                 SimpleItem("Clover", 3),
                 SimpleItem("Missile", 1),
-                SimpleItem("Behemoth",1)
+                SimpleItem("Behemoth",3)
             };
 
             // Speedy Beetle
@@ -234,7 +235,7 @@ namespace MonsterVariants
                 bodyName = "Vulture",
                 spawnRate = Modules.Config.artilleryVultureSpawnRate.Value,
                 variantTier = MonsterVariantTier.Uncommon,
-                sizeMultiplier = 2f,
+                sizeMultiplier = 1.2f,
                 healthMultiplier = 1f,
                 moveSpeedMultiplier = 1f,
                 attackSpeedMultiplier = 4f,
@@ -243,7 +244,7 @@ namespace MonsterVariants
                 armorBonus = 100f,
                 customInventory = artilleryInventory,
                 meshReplacement = null,
-                materialReplacement = SimpleMaterialReplacement(solusMat),
+                materialReplacement = MultiMaterialReplacement(new Dictionary<int, Material> { { 0, perforatorMat }, { 2, solusMat } }),
                 skillReplacement = null
             });
         }
@@ -261,6 +262,21 @@ namespace MonsterVariants
             };
 
             return matReplacement;
+        }
+
+        // helper for multiple material replacement, takes a dictionary with <renderer,material>
+        public static MonsterMaterialReplacement[] MultiMaterialReplacement(Dictionary<int, Material> newMaterials)
+        {
+            List<MonsterMaterialReplacement> matReplacement = new List<MonsterMaterialReplacement>();
+            foreach(KeyValuePair<int, Material> kvp in newMaterials)
+            {
+                MonsterMaterialReplacement replacement = ScriptableObject.CreateInstance<MonsterMaterialReplacement>();
+                replacement.rendererIndex = kvp.Key;
+                replacement.material = kvp.Value;
+                matReplacement.Add(replacement);
+            }
+
+            return matReplacement.ToArray();
         }
 
         // helpers for adding simple variants

--- a/MonsterVariants/MainPlugin.cs
+++ b/MonsterVariants/MainPlugin.cs
@@ -33,6 +33,7 @@ namespace MonsterVariants
             Material visionsMat = UnityEngine.Object.Instantiate(itemDisplayRuleSet.FindItemDisplayRuleGroup("LunarPrimaryReplacement").rules[0].followerPrefab.GetComponentInChildren<MeshRenderer>().material);
             Material ghostMat = Resources.Load<Material>("Materials/matGhostEffect");
             Material shatterspleenMat = UnityEngine.Object.Instantiate(itemDisplayRuleSet.FindItemDisplayRuleGroup("BleedOnHitAndExplode").rules[0].followerPrefab.GetComponentInChildren<MeshRenderer>().material);
+            Material solusMat = UnityEngine.Object.Instantiate(Resources.Load<GameObject>("Prefabs/CharacterBodies/RoboBallBossBody").GetComponentInChildren<CharacterModel>().baseRendererInfos[0].defaultMaterial);
 
             //Mesh beedlMesh = Modules.Assets.armoredMesh;
             //Mesh beedlSpeedMesh = Modules.Assets.speedyBeetleMesh;
@@ -84,6 +85,14 @@ namespace MonsterVariants
                 SimpleItem("UtilitySkillMagazine", 2),
                 SimpleItem("CritGlasses", 4),
                 SimpleItem("BleedOnHitAndExplode", 1)
+            };
+
+            // Artillery Vulture inventory
+            ItemInfo[] artilleryInventory = new ItemInfo[]
+            {
+                SimpleItem("Clover", 3),
+                SimpleItem("Missile", 1),
+                SimpleItem("Behemoth",1)
             };
 
             // Speedy Beetle
@@ -219,8 +228,26 @@ namespace MonsterVariants
                 skillReplacement = null
             });
 
+            // Artillery Vulture
+            AddVariant(new MonsterVariantInfo
+            {
+                bodyName = "Vulture",
+                spawnRate = Modules.Config.artilleryVultureSpawnRate.Value,
+                variantTier = MonsterVariantTier.Uncommon,
+                sizeMultiplier = 2f,
+                healthMultiplier = 1f,
+                moveSpeedMultiplier = 1f,
+                attackSpeedMultiplier = 4f,
+                damageMultiplier = 0.5f,
+                armorMultiplier = 1f,
+                armorBonus = 100f,
+                customInventory = artilleryInventory,
+                meshReplacement = null,
+                materialReplacement = SimpleMaterialReplacement(solusMat),
+                skillReplacement = null
+            });
         }
-       
+
         // helper for simplifying mat replacements
         public static MonsterMaterialReplacement[] SimpleMaterialReplacement(Material newMaterial)
         {

--- a/MonsterVariants/Modules/Config.cs
+++ b/MonsterVariants/Modules/Config.cs
@@ -24,6 +24,8 @@ namespace MonsterVariants.Modules
 
         public static ConfigEntry<float> clottedImpSpawnRate;
 
+        public static ConfigEntry<float> artilleryVultureSpawnRate;
+
         public static void ReadConfig()
         {
             armoredBeetleSpawnRate = MainPlugin.instance.Config.Bind<float>(new ConfigDefinition("01 - Spawn Rates", "Armored Beetle"), 10f, new ConfigDescription("Chance for Armored Beetle variant to spawn (percentage, 1-100)", null, Array.Empty<object>()));
@@ -44,6 +46,8 @@ namespace MonsterVariants.Modules
             beetleGuardBruteSpawnRate = MainPlugin.instance.Config.Bind<float>(new ConfigDefinition("01 - Spawn Rates", "Beetle Guard Brute"), 25f, new ConfigDescription("Chance for Beetle Guard Brute variant to spawn (percentage, 1-100)", null, Array.Empty<object>()));
 
             clottedImpSpawnRate = MainPlugin.instance.Config.Bind<float>(new ConfigDefinition("01 - Spawn Rates", "Clotted Imp"), 5f, new ConfigDescription("Chance for Clotted Imp variant to spawn (percentage, 1-100)", null, Array.Empty<object>()));
+
+            artilleryVultureSpawnRate = MainPlugin.instance.Config.Bind<float>(new ConfigDefinition("01 - Spawn Rates", "Artillery Vulture"), 5f, new ConfigDescription("Chance for Artillery Vulture variant to spawn (percentage, 1-100)", null, Array.Empty<object>()));
         }
     }
 }

--- a/MonsterVariants/Modules/Config.cs
+++ b/MonsterVariants/Modules/Config.cs
@@ -22,6 +22,8 @@ namespace MonsterVariants.Modules
 
         public static ConfigEntry<float> beetleGuardBruteSpawnRate;
 
+        public static ConfigEntry<float> clottedImpSpawnRate;
+
         public static void ReadConfig()
         {
             armoredBeetleSpawnRate = MainPlugin.instance.Config.Bind<float>(new ConfigDefinition("01 - Spawn Rates", "Armored Beetle"), 10f, new ConfigDescription("Chance for Armored Beetle variant to spawn (percentage, 1-100)", null, Array.Empty<object>()));
@@ -40,6 +42,8 @@ namespace MonsterVariants.Modules
             spectralJellyfishSpawnRate = MainPlugin.instance.Config.Bind<float>(new ConfigDefinition("01 - Spawn Rates", "Spectral Jellyfish"), 4f, new ConfigDescription("Chance for Spectral Jellyfish variant to spawn (percentage, 1-100)", null, Array.Empty<object>()));
 
             beetleGuardBruteSpawnRate = MainPlugin.instance.Config.Bind<float>(new ConfigDefinition("01 - Spawn Rates", "Beetle Guard Brute"), 25f, new ConfigDescription("Chance for Beetle Guard Brute variant to spawn (percentage, 1-100)", null, Array.Empty<object>()));
+
+            clottedImpSpawnRate = MainPlugin.instance.Config.Bind<float>(new ConfigDefinition("01 - Spawn Rates", "Clotted Imp"), 5f, new ConfigDescription("Chance for Clotted Imp variant to spawn (percentage, 1-100)", null, Array.Empty<object>()));
         }
     }
 }

--- a/MonsterVariants/Modules/Config.cs
+++ b/MonsterVariants/Modules/Config.cs
@@ -39,7 +39,7 @@ namespace MonsterVariants.Modules
             cursedJellyfishSpawnRate = MainPlugin.instance.Config.Bind<float>(new ConfigDefinition("01 - Spawn Rates", "Cursed Jellyfish"), 1f, new ConfigDescription("Chance for Cursed Jellyfish variant to spawn (percentage, 1-100)", null, Array.Empty<object>()));
             spectralJellyfishSpawnRate = MainPlugin.instance.Config.Bind<float>(new ConfigDefinition("01 - Spawn Rates", "Spectral Jellyfish"), 4f, new ConfigDescription("Chance for Spectral Jellyfish variant to spawn (percentage, 1-100)", null, Array.Empty<object>()));
 
-            nuclearJellyfishSpawnRate = MainPlugin.instance.Config.Bind<float>(new ConfigDefinition("01 - Spawn Rates", "Beetle Guard Brute"), 25f, new ConfigDescription("Chance for Beetle Guard Brute variant to spawn (percentage, 1-100)", null, Array.Empty<object>()));
+            beetleGuardBruteSpawnRate = MainPlugin.instance.Config.Bind<float>(new ConfigDefinition("01 - Spawn Rates", "Beetle Guard Brute"), 25f, new ConfigDescription("Chance for Beetle Guard Brute variant to spawn (percentage, 1-100)", null, Array.Empty<object>()));
         }
     }
 }


### PR DESCRIPTION
This was causing config spawn rate options to not work properly and preventing all variants defined after the Beetle Guard Brute from spawning.