### PR TITLE
Add a givesRewards Boolean.

### DIFF
--- a/MonsterVariants/Components/VariantHandler.cs
+++ b/MonsterVariants/Components/VariantHandler.cs
@@ -11,6 +11,8 @@ namespace MonsterVariants.Components
     {
         [SyncVar]
         public bool isVariant = false;
+        
+        public bool givesRewards;
 
         public float spawnRate = 1f;
         public float healthModifier = 1f;


### PR DESCRIPTION
Decided to propose this new variable for cases with extremely common variants (Such as Speedy beetles)
The main use of the boolean is inside my addon MonsterVariants+, where variants with this boolean set to false will not give any kind of rewards whatsoever.